### PR TITLE
[티켓번호 없음] feat: 카카오 로그인 관련 타입 정의 추가

### DIFF
--- a/src/types/schema/userSchema.ts
+++ b/src/types/schema/userSchema.ts
@@ -61,3 +61,43 @@ export const SignupResponseSchema = z.object({
 
 export type SignupRequest = z.infer<typeof SignupRequestSchema>;
 export type SignupResponse = z.infer<typeof SignupResponseSchema>;
+
+// 카카오 로그인 관련 스키마
+export const KakaoUserInfoSchema = z.object({
+  id: z.number(),
+  properties: z.object({
+    nickname: z.string(),
+    profile_image: z.string().nullable(),
+  }),
+  kakao_account: z
+    .object({
+      email: z.string().email().optional(),
+      email_verified: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export const KakaoAuthResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number(),
+  scope: z.string().optional(),
+});
+
+export const KakaoLoginRequestSchema = z.object({
+  userInfo: KakaoUserInfoSchema,
+  accessToken: z.string(),
+});
+
+export const KakaoLoginResponseSchema = z.object({
+  user: UserSchema,
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  isNewUser: z.boolean().optional(),
+});
+
+export type KakaoUserInfo = z.infer<typeof KakaoUserInfoSchema>;
+export type KakaoAuthResponse = z.infer<typeof KakaoAuthResponseSchema>;
+export type KakaoLoginRequest = z.infer<typeof KakaoLoginRequestSchema>;
+export type KakaoLoginResponse = z.infer<typeof KakaoLoginResponseSchema>;


### PR DESCRIPTION
## ⭐️ 작업 내역

<!--- 작업 내역에 대해 간단하게 작성해주세요. -->
- KakaoUserInfo: 카카오 API 사용자 정보 타입
- KakaoAuthResponse: 카카오 인증 응답 타입
- KakaoLoginRequest: 백엔드 로그인 요청 타입
- KakaoLoginResponse: 백엔드 로그인 응답 타입
- Zod 스키마와 TypeScript 타입 모두 정의

## 💡 변경 사항

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- `src/types/schema/userSchema.ts` 에 정의 해 뒀습니다.

## 🎱 연관된 이슈 번호

<!-- 내용에 '#'을 입력하시면 github issues에 등록된 이슈에서 선택하실 수 있습니다.  -->

-

## 📢 전달 사항 (선택)

<!-- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

-

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- @htak0601 
