### PR TITLE
[P6-163] feat: 예약 에러 처리 개선 - 409 에러 구분 처리

### DIFF
--- a/src/app/(global)/activities/[id]/components/reservation-block/Reservation.tsx
+++ b/src/app/(global)/activities/[id]/components/reservation-block/Reservation.tsx
@@ -61,8 +61,19 @@ const Reservation = ({ data }: Props) => {
       if (response.status === 201) {
         alert('예약이 완료되었습니다.');
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('예약 생성 실패:', error);
+
+      // 409 에러인 경우 (이미 확정 예약이 있는 경우)
+      if (error && typeof error === 'object' && 'response' in error) {
+        const axiosError = error as { response?: { status?: number } };
+        if (axiosError.response?.status === 409) {
+          alert('해당 날짜에 이미 확정 예약이 있는 체험을 예약할 수 없습니다.');
+          return;
+        }
+      }
+
+      // 그 외의 에러인 경우
       alert('예약 생성에 실패했습니다. 다시 시도해주세요.');
     }
   };


### PR DESCRIPTION
## ⭐️ 작업 내역

<!--- 작업 내역에 대해 간단하게 작성해주세요. -->

- 기존의 '확정 예약이 있는 날짜에 예약'시의 에러도 재시도하라는 알럿을 띄웠던 부분 분기처리

## 💡 변경 사항

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- 409 에러: 이미 확정 예약이 있는 체험 예약 불가 알림
- 기타 에러: 예약 생성 실패 재시도 요청 알림
- TypeScript 타입 안전성 강화 (unknown 타입 사용)


## 🎱 연관된 이슈 번호

<!-- 내용에 '#'을 입력하시면 github issues에 등록된 이슈에서 선택하실 수 있습니다.  -->

- #206 

## 📢 전달 사항 (선택)

<!-- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

- 

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

-
